### PR TITLE
Improve Zephyr Device Tree Generation

### DIFF
--- a/docs/zephyr_installer.md
+++ b/docs/zephyr_installer.md
@@ -16,17 +16,18 @@ The script requires the following mandatory arguments:
 - `efx_dev_board`: Development kit name (e.g. ti60).
 - `zephyr_path`: Path to the Zephyr project.
 - `soc_h_path`: Path to the soc.h file.
+- `-em | --extmemory` : [Optional] Select external RAM memory (DDR). Internal memory will be used if no external memory detected in soc.h even with external memory selected.  
 
 Here is an example of how to run the script:
 
 ```
-python3 zephyr_installer.py {soc_name} {board_name} {efx_dev_board} {zephyr_path} {soc_h_path}
+python3 zephyr_installer.py {soc_name} {board_name} {efx_dev_board} {zephyr_path} {soc_h_path} {-em}
 ```
 
 Replace the {...} placeholders with your actual values.
 
-For example, if your SoC name is "my_soc", board name is "my_board", development kit name is "ti60", the Zephyr path is "/path/to/zephyr_project" and soc.h path is "/path/to/soc.h", you would run:
+For example, if your SoC name is "my_soc", board name is "my_board", development kit name is "ti60", the Zephyr path is "/path/to/zephyr_project", soc.h path is "/path/to/soc.h" and external memory, you would run:
 
 ```
-python3 zephyr_installer.py my_soc my_board ti60 /path/to/zephyr_project /path/to/soc.h
+python3 zephyr_installer.py my_soc my_board ti60 /path/to/zephyr_project /path/to/soc.h -em
 ```

--- a/drivers.json
+++ b/drivers.json
@@ -74,9 +74,8 @@
 	"root": {
 		"chosen": {
 			"name": "chosen",
-			"private_data": ["zephyr,sram = &ram0;"]
+			"private_data": [""]
 		}
-
 	},
 	"controller":{
 		"plic": {
@@ -106,6 +105,13 @@
 			"compatible": ["sifive,clint0"],
 			"private_data": [
 				"interrupts-extended = <&hlic0 3 &hlic0 7>;"
+			]
+		},
+		"uart": {
+			"compatible": ["efinix,sapphire-uart0"],
+			"private_data": [
+				"reg-names = \"base\";",
+				"current-speed = <115200>;"
 			]
 		},
 		"gpio": {
@@ -163,9 +169,49 @@
 					]
 				}
 
-			}
-				
+			}		
+		}, 
+		"root_ext": {
+			"chosen": {
+				"name": "chosen",
+				"private_data": ["zephyr,console = &uart0;\n\tzephyr,shell-uart = &uart0;\n\tzephyr,sram = &external_ram;"]
+			},
+			"aliases": {
+				"name": "aliases",
+				"private_data": ["led0 = &green_led;"]
+			},
 
+			"leds": {
+				"name": "leds",
+				"private_data": [
+					"compatible = \"gpio-leds\";"
+				],
+
+				"green_led: led0": {
+					"name": "green_led: led0",
+					"private_data": [
+						"gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;",
+						"label = \"Green LED 3\";"
+					]
+				},
+
+				"red_led: led1": {
+					"name": "red_led: led1",
+					"private_data": [
+						"gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;",
+						"label = \"Red LED 2\";"
+					]
+				},
+
+				"blue_led: led2": {
+					"name": "blue_led: led2",
+					"private_data": [
+						"gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;",
+						"label = \"Blue LED 1\";"
+					]
+				}
+
+			}		
 		}
 	},
     "dts": {


### PR DESCRIPTION
- Fix keywords to identify RISC-V Extension in soc.h
- Add support for external memory configuration 
- Add argument, -em for user to use external memory
- Update argument os to positional, linux or zephyr selection 
- Fix missing data for UART in device tree
- Fix wrong kconfig path `soc/riscv/riscv-privilege/efinix-sapphire/Kconfig.soc`
- Add symbol CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC to set the running peripheral clock
